### PR TITLE
Feature/route filters UI

### DIFF
--- a/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
+++ b/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
@@ -5,6 +5,9 @@ import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isFocused;
+import static androidx.test.espresso.matcher.ViewMatchers.isNotFocused;
+import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
@@ -33,7 +36,7 @@ public class RouteFilterPopupTest {
         onView(withId(R.id.openRouteFilterButton)).perform(click());
 
         // check that the menu is displayed
-        onView(withId(R.id.routeFilterTitle)).check(matches(isDisplayed()));
+        onView(withId(R.id.routeFilterMenu)).check(matches(isDisplayed()));
     }
 
     // test that clicking Close button closes route filter menu
@@ -45,7 +48,20 @@ public class RouteFilterPopupTest {
         // click the close button
         onView(withId(R.id.closeRouteFilterButton)).perform(click());
 
-        onView(withId(R.id.routeFilterTitle)).check(doesNotExist());
+        // check that the menu no longer exists
+        onView(withId(R.id.routeFilterMenu)).check(doesNotExist());
+    }
+
+    @Test
+    public void closeRouteFiltersMenuClickOutside() {
+        // open the route filters
+        onView(withId(R.id.openRouteFilterButton)).perform(click());
+
+        // click outside the route filter
+        onView(isRoot()).perform(click());
+
+        // check that the menu no longer focused (will close automatically)
+        onView(withId(R.id.routeFilterMenu)).check(matches(isNotFocused()));
     }
 
 

--- a/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
+++ b/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
@@ -135,4 +135,25 @@ public class RouteFilterPopupTest {
         onView(withId(R.id.indoorsOnlyCheckBox)).check(matches(isChecked()));
     }
 
+    // test that clicking Close button does not save filters on subsequent loads
+    @Test
+    public void closeDoesNotSaveFilters() {
+        // open the filters menu
+        onView(withId(R.id.openRouteFilterButton)).perform(click());
+
+        // change the checkboxes from their default values
+        onView(withId(R.id.fastestRouteCheckBox)).perform(click());
+        onView(withId(R.id.indoorsOnlyCheckBox)).perform(click());
+
+        // close settings by pressing close button
+        onView(withId(R.id.closeRouteFilterButton)).perform(click());
+
+        // re-open the filters menu
+        onView(withId(R.id.openRouteFilterButton)).perform(click());
+
+        // check that checkboxes have old loaded values
+        onView(withId(R.id.fastestRouteCheckBox)).check(matches(isChecked()));
+        onView(withId(R.id.indoorsOnlyCheckBox)).check(matches(isNotChecked()));
+    }
+
 }

--- a/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
+++ b/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
@@ -6,7 +6,6 @@ import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.isFocused;
 import static androidx.test.espresso.matcher.ViewMatchers.isNotChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isNotFocused;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
@@ -18,8 +17,6 @@ import android.content.SharedPreferences;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import com.example.swen766_bettermaps.ui.home.route_filter.RouteFilterSettings;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -87,17 +84,13 @@ public class RouteFilterPopupTest {
 
     // vv TEST SAVING SETTINGS vv
 
-    private static final String PREFS_NAME = "RouteFilters";
-    private static final String KEY_IS_FASTEST_ROUTE = "isFastestRoute";
-    private static final String KEY_IS_INDOORS_ONLY = "isIndoorsOnly";
-
-    private SharedPreferences sharedPreferences;
-
     @Before
     public void setUp() {
+        String PREFS_NAME = "RouteFilters";
         // Get the SharedPreferences instance
         Context context = ApplicationProvider.getApplicationContext();
-        sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences sharedPreferences =
+                context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
 
         // Clear SharedPreferences before each test to avoid interference between tests
         sharedPreferences.edit().clear().apply();

--- a/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
+++ b/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
@@ -4,8 +4,10 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isFocused;
+import static androidx.test.espresso.matcher.ViewMatchers.isNotChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isNotFocused;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -16,6 +18,8 @@ import android.content.SharedPreferences;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.example.swen766_bettermaps.ui.home.route_filter.RouteFilterSettings;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -99,5 +103,15 @@ public class RouteFilterPopupTest {
         sharedPreferences.edit().clear().apply();
     }
 
+    // test that opening the filter menu for the first time loads default values
+    @Test
+    public void firstOpenLoadsDefaults() {
+        // open the filters menu
+        onView(withId(R.id.openRouteFilterButton)).perform(click());
+
+        // check that checkboxes have default loaded values
+        onView(withId(R.id.fastestRouteCheckBox)).check(matches(isChecked()));
+        onView(withId(R.id.indoorsOnlyCheckBox)).check(matches(isNotChecked()));
+    }
 
 }

--- a/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
+++ b/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
@@ -114,4 +114,25 @@ public class RouteFilterPopupTest {
         onView(withId(R.id.indoorsOnlyCheckBox)).check(matches(isNotChecked()));
     }
 
+    // test that clicking Apply button saves filters on subsequent loads
+    @Test
+    public void applySavesFilters() {
+        // open the filters menu
+        onView(withId(R.id.openRouteFilterButton)).perform(click());
+
+        // change the checkboxes from their default values
+        onView(withId(R.id.fastestRouteCheckBox)).perform(click());
+        onView(withId(R.id.indoorsOnlyCheckBox)).perform(click());
+
+        // apply settings by pressing apply button
+        onView(withId(R.id.applyRouteFilterButton)).perform(click());
+
+        // re-open the filters menu
+        onView(withId(R.id.openRouteFilterButton)).perform(click());
+
+        // check that checkboxes have new loaded values
+        onView(withId(R.id.fastestRouteCheckBox)).check(matches(isNotChecked()));
+        onView(withId(R.id.indoorsOnlyCheckBox)).check(matches(isChecked()));
+    }
+
 }

--- a/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
+++ b/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
@@ -1,0 +1,52 @@
+package com.example.swen766_bettermaps;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
+ */
+@RunWith(AndroidJUnit4.class)
+public class RouteFilterPopupTest {
+
+    @Rule
+    public ActivityScenarioRule<MainActivity> activityScenarioRule =
+            new ActivityScenarioRule<>(MainActivity.class);
+
+    // test that open route filter button opens route filter menu
+    @Test
+    public void openRouteFiltersMenu() {
+        // open the route filters
+        onView(withId(R.id.openRouteFilterButton)).perform(click());
+
+        // check that the menu is displayed
+        onView(withId(R.id.routeFilterTitle)).check(matches(isDisplayed()));
+    }
+
+    // test that clicking Close button closes route filter menu
+    @Test
+    public void closeRouteFiltersMenuButton() {
+        // open the route filters
+        onView(withId(R.id.openRouteFilterButton)).perform(click());
+
+        // click the close button
+        onView(withId(R.id.closeRouteFilterButton)).perform(click());
+
+        onView(withId(R.id.routeFilterTitle)).check(doesNotExist());
+    }
+
+
+}

--- a/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
+++ b/SWEN766BetterMaps/app/src/androidTest/java/com/example/swen766_bettermaps/RouteFilterPopupTest.java
@@ -10,9 +10,14 @@ import static androidx.test.espresso.matcher.ViewMatchers.isNotFocused;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,7 +46,7 @@ public class RouteFilterPopupTest {
 
     // test that clicking Close button closes route filter menu
     @Test
-    public void closeRouteFiltersMenuButton() {
+    public void closeRouteFiltersMenuCloseButton() {
         // open the route filters
         onView(withId(R.id.openRouteFilterButton)).perform(click());
 
@@ -62,6 +67,36 @@ public class RouteFilterPopupTest {
 
         // check that the menu no longer focused (will close automatically)
         onView(withId(R.id.routeFilterMenu)).check(matches(isNotFocused()));
+    }
+
+    @Test
+    public void closeRouteFiltersMenuApplyButton() {
+        // open the route filters
+        onView(withId(R.id.openRouteFilterButton)).perform(click());
+
+        // click the close button
+        onView(withId(R.id.applyRouteFilterButton)).perform(click());
+
+        // check that the menu no longer exists
+        onView(withId(R.id.routeFilterMenu)).check(doesNotExist());
+    }
+
+    // vv TEST SAVING SETTINGS vv
+
+    private static final String PREFS_NAME = "RouteFilters";
+    private static final String KEY_IS_FASTEST_ROUTE = "isFastestRoute";
+    private static final String KEY_IS_INDOORS_ONLY = "isIndoorsOnly";
+
+    private SharedPreferences sharedPreferences;
+
+    @Before
+    public void setUp() {
+        // Get the SharedPreferences instance
+        Context context = ApplicationProvider.getApplicationContext();
+        sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+
+        // Clear SharedPreferences before each test to avoid interference between tests
+        sharedPreferences.edit().clear().apply();
     }
 
 

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/MainActivity.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/MainActivity.java
@@ -1,7 +1,11 @@
 package com.example.swen766_bettermaps;
 
 import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageButton;
 
+import com.example.swen766_bettermaps.ui.home.route_filter.RouteFilterPopupWindow;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
@@ -43,6 +47,10 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         if (mapFragment != null) {
             mapFragment.getMapAsync(this);
         }
+
+        // button to open filters
+        ImageButton openFilterButton = findViewById(R.id.openRouteFilterButton);
+        openFilterButton.setOnClickListener(view -> openRouteFilters(view));
     }
 
     @Override
@@ -53,5 +61,12 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         LatLng RIT = new LatLng(43.0839295, -77.680005); // Example coordinates (Sydney)
         mMap.addMarker(new MarkerOptions().position(RIT).title("Golisano Hall on RIT Campus"));
         mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(RIT, 10)); // Zoom level 10
+    }
+
+    public void openRouteFilters(View view) {
+
+        RouteFilterPopupWindow routeFilterPopupWindow =
+                new RouteFilterPopupWindow(MainActivity.this);
+        routeFilterPopupWindow.show(view);
     }
 }

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/MainActivity.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/MainActivity.java
@@ -2,7 +2,6 @@ package com.example.swen766_bettermaps;
 
 import android.os.Bundle;
 import android.view.View;
-import android.widget.Button;
 import android.widget.ImageButton;
 
 import com.example.swen766_bettermaps.ui.home.route_filter.RouteFilterPopupWindow;
@@ -50,7 +49,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
 
         // button to open filters
         ImageButton openFilterButton = findViewById(R.id.openRouteFilterButton);
-        openFilterButton.setOnClickListener(view -> openRouteFilters(view));
+        openFilterButton.setOnClickListener(this::openRouteFilters);
     }
 
     @Override
@@ -63,8 +62,8 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(RIT, 10)); // Zoom level 10
     }
 
+    // opens the route filters popup menu
     public void openRouteFilters(View view) {
-
         RouteFilterPopupWindow routeFilterPopupWindow =
                 new RouteFilterPopupWindow(MainActivity.this);
         routeFilterPopupWindow.show(view);

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/RouteFilterPopupWindow.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/RouteFilterPopupWindow.java
@@ -1,0 +1,145 @@
+package com.example.swen766_bettermaps.ui.home;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.LinearLayout;
+import android.widget.PopupWindow;
+import android.widget.Toast;
+
+import com.example.swen766_bettermaps.R;
+
+/**
+ * Data object representing the current route filter settings.
+ * This object implements the builder pattern, so instantiate it with
+ * <code>RouteFilterSettings settings = new RouteFilterSettings.Builder()
+ * {setSettings...}.build()</code>
+ */
+class RouteFilterSettings {
+
+    private final boolean isFastestRoute;  // whether user prefers the fastest route
+    private final boolean isIndoorsOnly;   // whether user wants only indoor routes
+
+    // Builder pattern to create filter settings
+    public static class Builder {
+        private boolean isFastestRoute = true;
+        private boolean isIndoorsOnly = false;
+
+        /**
+         * Set if the user prefers the fastest route.
+         * @param isFastestRoute
+         * @return Reference to the builder, for chain method call instantiation.
+         */
+        public Builder setFastestRoute(boolean isFastestRoute) {
+            this.isFastestRoute = isFastestRoute;
+            return this;
+        }
+
+        /**
+         * Set if the user prefers only traveling indoors.
+         * @param isIndoorsOnly
+         * @return Reference to the builder, for chain method call instantiation.
+         */
+        public Builder setUseIndoorsOnly(boolean isIndoorsOnly) {
+            this.isIndoorsOnly = isIndoorsOnly;
+            return this;
+        }
+
+        /**
+         * Build the route filter settings.
+         * @return Route filter settings. Defaults: `isFastestRoute = true`,
+         * `isIndoorsOnly = false`.
+         */
+        public RouteFilterSettings build() {
+            return new RouteFilterSettings(this);
+        }
+    }
+    // private to prevent explicit instantiation
+    private RouteFilterSettings(Builder builder) {
+        this.isFastestRoute = builder.isFastestRoute;
+        this.isIndoorsOnly = builder.isIndoorsOnly;
+    }
+
+    /**
+     * Does the user prefer using the fastest route?
+     */
+    public boolean getIsFastestRoute() {
+        return this.isFastestRoute;
+    }
+
+    /**
+     * Does the user prefer traveling indoors?
+     */
+    public boolean getIsIndoorsOnly() {
+        return this.isIndoorsOnly;
+    }
+
+}
+
+public class RouteFilterPopupWindow {
+
+    private PopupWindow popupWindow;
+    private View popupView;
+
+    // Constructor accepts context for inflating and anchor view for positioning
+    public RouteFilterPopupWindow(Context context,View anchorView) {
+        // inflate the layout for the filter menu
+        LayoutInflater inflater = (LayoutInflater) context.getSystemService(
+                Context.LAYOUT_INFLATER_SERVICE);
+        popupView = inflater.inflate(R.layout.route_filter_menu, null);
+
+        // init PopupWindow
+        popupWindow = new PopupWindow(
+                popupView,
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT);
+
+        // set up popup window properties
+        popupWindow.setFocusable(true); // allow interaction
+        popupWindow.setOutsideTouchable(true); // close when outside clicked
+        popupWindow.setAnimationStyle(android.R.style.Animation_Dialog); // animate
+
+        // handle Apply Filters button
+        Button applyButton = popupView.findViewById(R.id.applyRouteFilterButton);
+        applyButton.setOnClickListener(view -> {
+            // get values from filter options
+            CheckBox fastestRouteCheckBox = popupView.findViewById(R.id.fastestRouteCheckBox);
+            CheckBox indoorOnlyCheckBox = popupView.findViewById(R.id.indoorsOnlyCheckBox);
+
+            boolean fastestRoute = fastestRouteCheckBox.isChecked();
+            boolean indoorOnly = indoorOnlyCheckBox.isChecked();
+
+            RouteFilterSettings settings = new RouteFilterSettings.Builder()
+                    .setFastestRoute(fastestRoute)
+                    .setUseIndoorsOnly(indoorOnly)
+                    .build();
+
+            // apply filters
+            applyFilters(settings);
+
+            // dismiss window
+            popupWindow.dismiss();
+        });
+
+        // handle Close button - close without saving
+        Button closeButton = popupView.findViewById(R.id.closeRouteFilterButton);
+        closeButton.setOnClickListener(view -> { popupWindow.dismiss(); });
+    }
+
+    // Display the Popup Window at the given anchor view
+    public void show(View anchorView) {
+        // position window below anchor
+        popupWindow.showAsDropDown(anchorView, 0, 0);
+    }
+
+    // Apply filters based on given values
+    public void applyFilters(RouteFilterSettings settings) {
+        // test with a toast
+        Toast.makeText(popupView.getContext(),
+                "Applied Route Filters: Fastest Route? = " + settings.getIsFastestRoute() +
+                        ", Indoors Only? = " + settings.getIsIndoorsOnly(),
+                Toast.LENGTH_SHORT).show();
+    }
+}

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterPopupWindow.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterPopupWindow.java
@@ -83,6 +83,14 @@ public class RouteFilterPopupWindow {
     }
 
     /**
+     * Retrieve the current route filter settings.
+     * @return An object containing all route filter information.
+     */
+    public RouteFilterSettings getSettings() {
+        return this.previousSettings;
+    }
+
+    /**
      *  Display the Popup Window at the given anchor view.
      */
     public void show(View anchorView) {

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterPopupWindow.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterPopupWindow.java
@@ -134,10 +134,8 @@ public class RouteFilterPopupWindow {
       */
     private void debugShowFilters() {
         // test with a toast
-        Toast.makeText(popupView.getContext(),
-                "Route Filters: " +
-                        "Fastest Route? = " + this.previousSettings.getIsFastestRoute() +
-                        ", Indoors Only? = " + this.previousSettings.getIsIndoorsOnly(),
+        Toast.makeText(popupView.getContext(), 
+                "Route Filters: " + this.previousSettings.toString(),
                 Toast.LENGTH_SHORT).show();
     }
 }

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterPopupWindow.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterPopupWindow.java
@@ -1,6 +1,7 @@
-package com.example.swen766_bettermaps.ui.home;
+package com.example.swen766_bettermaps.ui.home.route_filter;
 
 import android.content.Context;
+import android.view.Display;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
@@ -10,73 +11,6 @@ import android.widget.PopupWindow;
 import android.widget.Toast;
 
 import com.example.swen766_bettermaps.R;
-
-/**
- * Data object representing the current route filter settings.
- * This object implements the builder pattern, so instantiate it with
- * <code>RouteFilterSettings settings = new RouteFilterSettings.Builder()
- * {setSettings...}.build()</code>
- */
-class RouteFilterSettings {
-
-    private final boolean isFastestRoute;  // whether user prefers the fastest route
-    private final boolean isIndoorsOnly;   // whether user wants only indoor routes
-
-    // Builder pattern to create filter settings
-    public static class Builder {
-        private boolean isFastestRoute = true;
-        private boolean isIndoorsOnly = false;
-
-        /**
-         * Set if the user prefers the fastest route.
-         * @param isFastestRoute
-         * @return Reference to the builder, for chain method call instantiation.
-         */
-        public Builder setFastestRoute(boolean isFastestRoute) {
-            this.isFastestRoute = isFastestRoute;
-            return this;
-        }
-
-        /**
-         * Set if the user prefers only traveling indoors.
-         * @param isIndoorsOnly
-         * @return Reference to the builder, for chain method call instantiation.
-         */
-        public Builder setUseIndoorsOnly(boolean isIndoorsOnly) {
-            this.isIndoorsOnly = isIndoorsOnly;
-            return this;
-        }
-
-        /**
-         * Build the route filter settings.
-         * @return Route filter settings. Defaults: `isFastestRoute = true`,
-         * `isIndoorsOnly = false`.
-         */
-        public RouteFilterSettings build() {
-            return new RouteFilterSettings(this);
-        }
-    }
-    // private to prevent explicit instantiation
-    private RouteFilterSettings(Builder builder) {
-        this.isFastestRoute = builder.isFastestRoute;
-        this.isIndoorsOnly = builder.isIndoorsOnly;
-    }
-
-    /**
-     * Does the user prefer using the fastest route?
-     */
-    public boolean getIsFastestRoute() {
-        return this.isFastestRoute;
-    }
-
-    /**
-     * Does the user prefer traveling indoors?
-     */
-    public boolean getIsIndoorsOnly() {
-        return this.isIndoorsOnly;
-    }
-
-}
 
 public class RouteFilterPopupWindow {
 
@@ -128,13 +62,17 @@ public class RouteFilterPopupWindow {
         closeButton.setOnClickListener(view -> { popupWindow.dismiss(); });
     }
 
-    // Display the Popup Window at the given anchor view
+    /**
+     *  Display the Popup Window at the given anchor view.
+     */
     public void show(View anchorView) {
         // position window below anchor
         popupWindow.showAsDropDown(anchorView, 0, 0);
     }
 
-    // Apply filters based on given values
+    /**
+     * Apply filters based on given values.
+      */
     public void applyFilters(RouteFilterSettings settings) {
         // test with a toast
         Toast.makeText(popupView.getContext(),

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterPopupWindow.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterPopupWindow.java
@@ -1,5 +1,6 @@
 package com.example.swen766_bettermaps.ui.home.route_filter;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.view.LayoutInflater;
@@ -18,16 +19,17 @@ public class RouteFilterPopupWindow {
     private static final String KEY_IS_FASTEST_ROUTE = "isFastestRoute";
     private static final String KEY_IS_INDOORS_ONLY = "isIndoorsOnly";
 
-    private PopupWindow popupWindow;
-    private View popupView;
-    private Context context;
+    private final PopupWindow popupWindow;
+    private final View popupView;
+    private final Context context;
 
-    private CheckBox fastestRouteCheckBox;
-    private CheckBox indoorsOnlyCheckBox;
+    private final CheckBox fastestRouteCheckBox;
+    private final CheckBox indoorsOnlyCheckBox;
 
     private RouteFilterSettings previousSettings;
 
     // Constructor accepts context for inflating
+    @SuppressLint("InflateParams")
     public RouteFilterPopupWindow(Context context) {
         this.context = context;
 
@@ -55,12 +57,10 @@ public class RouteFilterPopupWindow {
         applyButton.setOnClickListener(view -> {
 
             // set new settings
-            RouteFilterSettings settings = new RouteFilterSettings.Builder()
+            this.previousSettings = new RouteFilterSettings.Builder()
                     .setFastestRoute(this.fastestRouteCheckBox.isChecked())
                     .setUseIndoorsOnly(this.indoorsOnlyCheckBox.isChecked())
                     .build();
-
-            this.previousSettings = settings;
 
             saveFilterSettings();
 

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterPopupWindow.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterPopupWindow.java
@@ -134,7 +134,7 @@ public class RouteFilterPopupWindow {
       */
     private void debugShowFilters() {
         // test with a toast
-        Toast.makeText(popupView.getContext(), 
+        Toast.makeText(popupView.getContext(),
                 "Route Filters: " + this.previousSettings.toString(),
                 Toast.LENGTH_SHORT).show();
     }

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterSettings.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterSettings.java
@@ -1,0 +1,73 @@
+package com.example.swen766_bettermaps.ui.home.route_filter;
+
+/**
+ * Data object representing the current route filter settings.
+ * This object implements the builder pattern, so instantiate it with
+ * <code>RouteFilterSettings settings = new RouteFilterSettings.Builder()
+ * {setSettings...}.build()</code>
+ */
+public class RouteFilterSettings {
+
+    private final boolean isFastestRoute;  // whether user prefers the fastest route
+    private final boolean isIndoorsOnly;   // whether user wants only indoor routes
+
+    /**
+     * Object that implements the builder pattern to construct a
+     * Route Filter Settings object. Defines defaults as:
+     * {`isFastestRoute = true, isIndoorsOnly = false}`
+     */
+    public static class Builder {
+        private boolean isFastestRoute = true;
+        private boolean isIndoorsOnly = false;
+
+        /**
+         * Set if the user prefers the fastest route.
+         * @param isFastestRoute
+         * @return Reference to the builder, for chain method call instantiation.
+         */
+        public Builder setFastestRoute(boolean isFastestRoute) {
+            this.isFastestRoute = isFastestRoute;
+            return this;
+        }
+
+        /**
+         * Set if the user prefers only traveling indoors.
+         * @param isIndoorsOnly
+         * @return Reference to the builder, for chain method call instantiation.
+         */
+        public Builder setUseIndoorsOnly(boolean isIndoorsOnly) {
+            this.isIndoorsOnly = isIndoorsOnly;
+            return this;
+        }
+
+        /**
+         * Build the route filter settings.
+         * @return Route filter settings. Defaults: `isFastestRoute = true`,
+         * `isIndoorsOnly = false`.
+         */
+        public RouteFilterSettings build() {
+            return new RouteFilterSettings(this);
+        }
+    }
+
+    // private to prevent explicit instantiation
+    private RouteFilterSettings(Builder builder) {
+        this.isFastestRoute = builder.isFastestRoute;
+        this.isIndoorsOnly = builder.isIndoorsOnly;
+    }
+
+    /**
+     * Does the user prefer using the fastest route? True = enabled.
+     */
+    public boolean getIsFastestRoute() {
+        return this.isFastestRoute;
+    }
+
+    /**
+     * Does the user prefer traveling indoors? True = enabled.
+     */
+    public boolean getIsIndoorsOnly() {
+        return this.isIndoorsOnly;
+    }
+
+}

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterSettings.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterSettings.java
@@ -1,5 +1,7 @@
 package com.example.swen766_bettermaps.ui.home.route_filter;
 
+import androidx.annotation.NonNull;
+
 /**
  * Data object representing the current route filter settings.
  * This object implements the builder pattern, so instantiate it with
@@ -22,7 +24,6 @@ public class RouteFilterSettings {
 
         /**
          * Set if the user prefers the fastest route.
-         * @param isFastestRoute
          * @return Reference to the builder, for chain method call instantiation.
          */
         public Builder setFastestRoute(boolean isFastestRoute) {
@@ -32,7 +33,6 @@ public class RouteFilterSettings {
 
         /**
          * Set if the user prefers only traveling indoors.
-         * @param isIndoorsOnly
          * @return Reference to the builder, for chain method call instantiation.
          */
         public Builder setUseIndoorsOnly(boolean isIndoorsOnly) {
@@ -70,6 +70,7 @@ public class RouteFilterSettings {
         return this.isIndoorsOnly;
     }
 
+    @NonNull
     @Override
     public String toString() {
         return "(Is Fastest Route? = " + this.isFastestRoute +

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterSettings.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterSettings.java
@@ -76,4 +76,14 @@ public class RouteFilterSettings {
                 ", Is Indoors Only? = " + this.isIndoorsOnly + ")";
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if(obj instanceof RouteFilterSettings) {
+            RouteFilterSettings rfs = (RouteFilterSettings) obj;
+            return this.isFastestRoute == rfs.isFastestRoute
+                    && this.isIndoorsOnly == rfs.isIndoorsOnly;
+        }
+        return false;
+    }
+
 }

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterSettings.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterSettings.java
@@ -70,4 +70,10 @@ public class RouteFilterSettings {
         return this.isIndoorsOnly;
     }
 
+    @Override
+    public String toString() {
+        return "[Is Fastest Route? = " + this.isFastestRoute +
+                ", Is Indoors Only? = " + this.isIndoorsOnly + "]";
+    }
+
 }

--- a/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterSettings.java
+++ b/SWEN766BetterMaps/app/src/main/java/com/example/swen766_bettermaps/ui/home/route_filter/RouteFilterSettings.java
@@ -72,8 +72,8 @@ public class RouteFilterSettings {
 
     @Override
     public String toString() {
-        return "[Is Fastest Route? = " + this.isFastestRoute +
-                ", Is Indoors Only? = " + this.isIndoorsOnly + "]";
+        return "(Is Fastest Route? = " + this.isFastestRoute +
+                ", Is Indoors Only? = " + this.isIndoorsOnly + ")";
     }
 
 }

--- a/SWEN766BetterMaps/app/src/main/res/drawable/circular_button_background.xml
+++ b/SWEN766BetterMaps/app/src/main/res/drawable/circular_button_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorPrimaryVariant">  <!-- Set the ripple color -->
+    <item>
+        <shape android:layout_width="wrap_content">
+            <solid android:color="?attr/colorPrimary" />
+            <corners android:radius="25dp" />  <!-- Circular shape -->
+        </shape>
+    </item>
+</ripple>

--- a/SWEN766BetterMaps/app/src/main/res/drawable/ic_filter.xml
+++ b/SWEN766BetterMaps/app/src/main/res/drawable/ic_filter.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M4.25,5.61C6.27,8.2 10,13 10,13v6c0,0.55 0.45,1 1,1h2c0.55,0 1,-0.45 1,-1v-6c0,0 3.72,-4.8 5.74,-7.39C20.25,4.95 19.78,4 18.95,4H5.04C4.21,4 3.74,4.95 4.25,5.61z"/>
+    
+</vector>

--- a/SWEN766BetterMaps/app/src/main/res/layout/activity_main.xml
+++ b/SWEN766BetterMaps/app/src/main/res/layout/activity_main.xml
@@ -1,20 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingTop="?attr/actionBarSize">
 
+    <!-- Button that triggers the filter popup -->
+
+    <!-- Icon button for opening filter settings -->
     <fragment
         android:id="@+id/map"
         android:name="com.google.android.gms.maps.SupportMapFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/nav_view"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0" />
+
+    <ImageButton
+        android:id="@+id/openRouteFilterButton"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:src="@drawable/ic_filter"
+        android:contentDescription="Open route filter settings"
+        android:background="@drawable/circular_button_background"
+        android:padding="12dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginStart="10dp"
+        android:scaleType="centerInside"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:importantForAccessibility="yes"
+        android:clickable="true"
+        android:focusable="true" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/nav_view"

--- a/SWEN766BetterMaps/app/src/main/res/layout/activity_main.xml
+++ b/SWEN766BetterMaps/app/src/main/res/layout/activity_main.xml
@@ -6,10 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingTop="?attr/actionBarSize">
-
-    <!-- Button that triggers the filter popup -->
-
-    <!-- Icon button for opening filter settings -->
+    
     <fragment
         android:id="@+id/map"
         android:name="com.google.android.gms.maps.SupportMapFragment"
@@ -22,6 +19,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="1.0" />
 
+    <!-- Icon button for opening filter settings -->
     <ImageButton
         android:id="@+id/openRouteFilterButton"
         android:layout_width="50dp"

--- a/SWEN766BetterMaps/app/src/main/res/layout/route_filter_menu.xml
+++ b/SWEN766BetterMaps/app/src/main/res/layout/route_filter_menu.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/routeFilterMenu"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"

--- a/SWEN766BetterMaps/app/src/main/res/layout/route_filter_menu.xml
+++ b/SWEN766BetterMaps/app/src/main/res/layout/route_filter_menu.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:background="@android:color/white"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/routeFilterTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Route Filter Options"
+        android:textSize="18sp"
+        android:paddingBottom="8dp" />
+
+    <CheckBox
+        android:id="@+id/fastestRouteCheckBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fastest route"
+        android:tooltipText="Disable to ignore fastest route."
+        android:checked="true"/>
+
+    <CheckBox
+        android:id="@+id/indoorsOnlyCheckBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Indoors only"
+        android:tooltipText="Enable to minimize outdoor routing."/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:weightSum="3"
+        android:paddingBottom="16dp">
+
+        <Button
+            android:id="@+id/applyRouteFilterButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="Apply Filters" />
+
+        <Button
+            android:id="@+id/closeRouteFilterButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Close" />
+
+    </LinearLayout>
+
+
+</LinearLayout>

--- a/SWEN766BetterMaps/app/src/test/java/com/example/swen766_bettermaps/RouteFilterSettingsTest.java
+++ b/SWEN766BetterMaps/app/src/test/java/com/example/swen766_bettermaps/RouteFilterSettingsTest.java
@@ -19,6 +19,7 @@ public class RouteFilterSettingsTest {
         assertEquals(expectedIsIndoors, settings.getIsIndoorsOnly());
     }
 
+    // build parameterized settings with chained builder class methods
     @Test
     public void buildParamsRFS() {
         boolean expectedIsFastest = false;

--- a/SWEN766BetterMaps/app/src/test/java/com/example/swen766_bettermaps/RouteFilterSettingsTest.java
+++ b/SWEN766BetterMaps/app/src/test/java/com/example/swen766_bettermaps/RouteFilterSettingsTest.java
@@ -1,0 +1,35 @@
+package com.example.swen766_bettermaps;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import com.example.swen766_bettermaps.ui.home.route_filter.RouteFilterSettings;
+
+public class RouteFilterSettingsTest {
+    // build default route filter settings with builder static class
+    @Test
+    public void buildDefaultRFS() {
+        boolean expectedIsFastest = true;
+        boolean expectedIsIndoors = false;
+
+        RouteFilterSettings settings = new RouteFilterSettings.Builder().build();
+
+        assertEquals(expectedIsFastest, settings.getIsFastestRoute());
+        assertEquals(expectedIsIndoors, settings.getIsIndoorsOnly());
+    }
+
+    @Test
+    public void buildParamsRFS() {
+        boolean expectedIsFastest = false;
+        boolean expectedIsIndoors = true;
+
+        RouteFilterSettings settings = new RouteFilterSettings.Builder()
+                .setFastestRoute(expectedIsFastest)
+                .setUseIndoorsOnly(expectedIsIndoors)
+                .build();
+
+        assertEquals(expectedIsFastest, settings.getIsFastestRoute());
+        assertEquals(expectedIsIndoors, settings.getIsIndoorsOnly());
+    }
+}


### PR DESCRIPTION
- Added Route Filter UI menu
    - Filters can be accessed from home fragment by pressing the filter button
    - Filters are shown in a popup window
    - Current filters include two checkboxes: 
        - Fastest Route - does the user prefer getting the fastest route?
        - Indoors Only - does the user prefer traveling indoors as much as possible?
    - Filters are saved to SharedPreferences whenever the Apply Filters button is pressed
    - Filters are *not* saved when the user presses the Close button or presses outside of the popup window
    - On subsequent app loads/filter opens, the previous settings are loaded from SharedPreferences into the menu
    - Settings are saved in a RouteFilterSettings object, which has accessors for the above checkbox booleans
 - Added unit tests for RouteFilterSettings and RouteFilterPopupWindow